### PR TITLE
Health component and EntityDeath trigger

### DIFF
--- a/src/game/components.rs
+++ b/src/game/components.rs
@@ -18,17 +18,21 @@ pub struct EntityDeath;
 //-------------------------------------------------------------------------------------------------------------------
 
 #[derive(Debug, Component)]
-pub struct Health {
+pub struct Health
+{
     pub current: usize,
     pub max: usize,
 }
 
-impl Health {
-    pub fn from_max(max: usize) -> Self {
+impl Health
+{
+    pub fn from_max(max: usize) -> Self
+    {
         Self { current: max, max }
     }
 
-    pub fn set_health(&mut self, new: usize) {
+    pub fn set_health(&mut self, new: usize)
+    {
         self.current = new.min(self.max)
     }
 }

--- a/src/game/components.rs
+++ b/src/game/components.rs
@@ -11,3 +11,26 @@ use bevy::prelude::*;
 pub struct Barrier;
 
 //-------------------------------------------------------------------------------------------------------------------
+
+#[derive(Debug, Clone, Copy, Event)]
+pub struct EntityDeath;
+
+//-------------------------------------------------------------------------------------------------------------------
+
+#[derive(Debug, Component)]
+pub struct Health {
+    pub current: usize,
+    pub max: usize,
+}
+
+impl Health {
+    pub fn from_max(max: usize) -> Self {
+        Self { current: max, max }
+    }
+
+    pub fn set_health(&mut self, new: usize) {
+        self.current = new.min(self.max)
+    }
+}
+
+//-------------------------------------------------------------------------------------------------------------------

--- a/src/game/components.rs
+++ b/src/game/components.rs
@@ -31,7 +31,7 @@ impl Health
         Self { current: max, max }
     }
 
-    pub fn set_health(&mut self, new: usize)
+    pub fn set_current(&mut self, new: usize)
     {
         self.current = new.min(self.max)
     }

--- a/src/game/player.rs
+++ b/src/game/player.rs
@@ -276,26 +276,25 @@ fn update_player_animation(
 fn spawn_player(mut c: Commands, constants: ReactRes<GameConstants>, animations: Res<SpriteAnimations>)
 {
     c.spawn((
-        Player { health: constants.player_base_hp },
+        Player,
         SpatialBundle::from_transform(Transform::default()),
         SpriteLayer::Objects,
         PlayerDirection::Up,
         Action::Standing,
         AabbSize(constants.player_size),
+        Health::from_max(constants.player_base_hp),
         //todo: scoping to GameState::Play means the player despawns on entering GameState::DayOver, even though
         // we may want to continue displaying the player in the background
         StateScoped(GameState::Play),
     ))
-    .set_sprite_animation(&animations, &constants.player_standing_animation);
+    .set_sprite_animation(&animations, &constants.player_standing_animation)
+    .observe(|trigger: Trigger<EntityDeath>, mut c: Commands| c.react().broadcast(PlayerDied));
 }
 
 //-------------------------------------------------------------------------------------------------------------------
 
 #[derive(Component, Debug)]
-pub struct Player
-{
-    pub health: usize,
-}
+pub struct Player;
 
 //-------------------------------------------------------------------------------------------------------------------
 

--- a/src/game/setup.rs
+++ b/src/game/setup.rs
@@ -42,9 +42,22 @@ fn check_end_condition(
     }
 
     // Condition: player health
-    if player.single().health == 0 {
-        c.react().broadcast(PlayerDied);
-        return;
+    // if player.single().health == 0 {
+    //     c.react().broadcast(PlayerDied);
+    //     return;
+    // }
+}
+
+//--------------------------------------------------------------------------------------------------------------------
+
+fn check_entity_health(mut c: Commands, entities: Query<(Entity, &Health), Changed<Health>>) {
+    for (id, health) in entities.iter() {
+        // dead if health is 0 (can't be less)
+        if health.current == 0 {
+            c.trigger_targets(EntityDeath, id);
+            // removes component because otherwise it would keep detecting it as dead
+            c.entity(id).remove::<Health>();
+        }
     }
 }
 
@@ -61,9 +74,10 @@ impl Plugin for GameSetupPlugin
                 (broadcast::<PlayerDied>(), broadcast::<PlayerSurvived>()),
                 send_day_over,
             )
-        })
-        .add_systems(OnEnter(GameState::Play), reset_game)
-        .add_systems(Update, check_end_condition.run_if(in_state(GameState::Play)));
+        });
+        app.add_systems(OnEnter(GameState::Play), reset_game);
+        // app.add_systems(Update, check_end_condition.run_if(in_state(GameState::Play)));
+        app.add_systems(Update, check_entity_health.run_if(in_state(GameState::Play)));
     }
 }
 

--- a/src/game/setup.rs
+++ b/src/game/setup.rs
@@ -50,7 +50,8 @@ fn check_end_condition(
 
 //--------------------------------------------------------------------------------------------------------------------
 
-fn check_entity_health(mut c: Commands, entities: Query<(Entity, &Health), Changed<Health>>) {
+fn check_entity_health(mut c: Commands, entities: Query<(Entity, &Health), Changed<Health>>)
+{
     for (id, health) in entities.iter() {
         // dead if health is 0 (can't be less)
         if health.current == 0 {

--- a/src/game/setup.rs
+++ b/src/game/setup.rs
@@ -40,12 +40,6 @@ fn check_end_condition(
         c.react().broadcast(PlayerSurvived);
         return;
     }
-
-    // Condition: player health
-    // if player.single().health == 0 {
-    //     c.react().broadcast(PlayerDied);
-    //     return;
-    // }
 }
 
 //--------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
- fairly simple Health component, with `current` and `max` fields, as well as `from_max` and `set_current` (checks against `max`) methods. 
- a system to query for anything with a Health component and check if `current` is 0. if it is, it sends an EntityDeath trigger and removes the Health component (to prevent it from continuing to find the same one)
- player: 
  - removed fields, is now a marker component
  - added Health component that uses `constants.player_base_hp`
  - an EntityDeath observer that broadcasts PlayerDied
  - removed relevant section of `check_end_condition`