### PR TITLE
swap bevy_lit with bevy_light_2d

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ rand_chacha = { version = "0.3" }
 serde = { version = "1.0" }
 tracing = { version = "0.1" }
 wasm-timer = { version = "0.2" }
-bevy_lit = { git= "https://github.com/malbernaz/bevy_lit" }
+bevy_light_2d = { version = "0.2" }
 
 # Profile for WASM release builds only.
 [profile.release]

--- a/src/game/light.rs
+++ b/src/game/light.rs
@@ -1,13 +1,23 @@
+use bevy::color::palettes::basic::*;
 use bevy::prelude::*;
 use bevy_cobweb::prelude::*;
-use bevy_lit::prelude::*;
+use bevy_light_2d::prelude::*;
 
 use crate::*;
 
 //-------------------------------------------------------------------------------------------------------------------
 
-fn update_light(mut light: ResMut<AmbientLight2d>, clock: Res<GameClock>, constants: ReactRes<GameConstants>)
+fn setup_light(mut c: Commands, camera: Query<Entity, With<MainCamera>>)
 {
+    c.entity(camera.single())
+        .insert(AmbientLight2d { color: Color::Srgba(WHITE), brightness: 1.0 });
+}
+
+//-------------------------------------------------------------------------------------------------------------------
+
+fn update_light(mut light: Query<&mut AmbientLight2d>, clock: Res<GameClock>, constants: ReactRes<GameConstants>)
+{
+    let mut light = light.single_mut();
     let day_progress = clock.elapsed.as_secs_f32() / constants.day_length_secs as f32;
 
     // get brighter until halfway through the day, then start going down
@@ -23,7 +33,8 @@ impl Plugin for LightPlugin
 {
     fn build(&self, app: &mut App)
     {
-        app.add_plugins(Lighting2dPlugin::default())
+        app.add_plugins(Light2dPlugin)
+            .add_systems(PostStartup, setup_light)
             .add_systems(Update, update_light.run_if(in_state(PlayState::Day)));
     }
 }

--- a/src/game/map.rs
+++ b/src/game/map.rs
@@ -6,7 +6,6 @@ use bevy::sprite::Anchor;
 use bevy_cobweb::prelude::*;
 use bevy_cobweb_ui::prelude::*;
 use bevy_ecs_tilemap::prelude::*;
-use bevy_lit::prelude::LightOccluder2d;
 use rand::Rng;
 use serde::{Deserialize, Serialize};
 
@@ -41,14 +40,7 @@ fn spawn_map(mut c: Commands, mut rng: ResMut<GameRng>, constants: ReactRes<Game
     let tilemap_tile_size: TilemapTileSize = constants.map_tile_size.into();
 
     // Background tilemap entity.
-    let bg_tilemap_entity = c
-        .spawn((
-            BackgroundTilemap,
-            LightOccluder2d {
-                half_size: constants.map_size.as_vec2() * constants.map_tile_size,
-            },
-        ))
-        .id();
+    let bg_tilemap_entity = c.spawn(BackgroundTilemap).id();
 
     // Spawn the elements of the tilemap.
     let mut tile_storage = TileStorage::empty(tilemap_size);

--- a/src/game/player.rs
+++ b/src/game/player.rs
@@ -5,7 +5,6 @@ use bevy::prelude::*;
 use bevy::sprite::{Anchor, MaterialMesh2dBundle};
 use bevy_cobweb::prelude::*;
 use bevy_cobweb_ui::prelude::*;
-use bevy_lit::prelude::LightOccluder2d;
 
 use crate::*;
 
@@ -380,7 +379,6 @@ fn spawn_player(
     c.spawn((
         Player,
         SpatialBundle::from_transform(Transform::default()),
-        LightOccluder2d { half_size: constants.player_size / 2.0 },
         SpriteLayer::Objects,
         PlayerDirection::Up,
         Action::Standing,

--- a/src/game/plugin.rs
+++ b/src/game/plugin.rs
@@ -19,8 +19,7 @@ impl Plugin for GamePlugin
             .add_plugins(GameUiPlugin)
             .add_plugins(GameClockPlugin)
             .add_plugins(GameCameraPlugin)
-            //todo: re-enable once webgl is supported
-            //.add_plugins(LightPlugin)
+            .add_plugins(LightPlugin)
             .configure_sets(
                 Update,
                 (PlayerUpdateSet, CameraUpdateSet, PowerUpUpdateSet)


### PR DESCRIPTION
removed all references to bevy_lit, and used bevy_light_2d in its place. `AmbientLight2d` is a component now, which is inserted on the camera (`MainCamera`) in PostStartup. the only real code that actually "does things" in the light system is the math to calculate the brightness, and that is completely unchanged.