### PR TITLE
try to spread enemies out a bit

### DIFF
--- a/src/game/attraction.rs
+++ b/src/game/attraction.rs
@@ -36,12 +36,14 @@ fn update_transforms_for_attraction(
             continue;
         };
 
+        let vector = target_transform.translation - transform.translation + attraction.target_offset.extend(0.);
+        if vector.length() <= attraction.stop_distance {
+            continue;
+        }
+
         // Move the entity toward its attraction source.
         let distance = attraction.update_and_get_distance(delta);
-        let direction =
-            Dir3::new(target_transform.translation - transform.translation + attraction.target_offset.extend(0.))
-                .map(|d| d.as_vec3())
-                .unwrap_or_default();
+        let direction = vector.normalize();
         let movement = direction * distance;
         transform.translation += movement;
     }
@@ -99,11 +101,14 @@ pub struct Attraction
 
     // offset to make movement more random and bunch up less
     target_offset: Vec2,
+
+    // how close to get before stopping, prevents jitter
+    stop_distance: f32,
 }
 
 impl Attraction
 {
-    pub fn new(target: Entity, max_velocity_tps: f32, acceleration: f32) -> Self
+    pub fn new(target: Entity, max_velocity_tps: f32, acceleration: f32, stop_distance: f32) -> Self
     {
         let current_vel = match acceleration {
             0. => max_velocity_tps,
@@ -115,6 +120,7 @@ impl Attraction
             acceleration,
             current_vel,
             target_offset: Vec2::ZERO,
+            stop_distance,
         }
     }
 

--- a/src/game/attraction.rs
+++ b/src/game/attraction.rs
@@ -66,17 +66,16 @@ fn update_enemy_target_offsets(
     let max_offset_length = 75.;
     let precise_follow_dist = 75.; // when they will start following the player more precisely
     for (mut attraction, transform) in enemies.iter_mut() {
+        let distance = (player_transform.translation - transform.translation).length();
         // randomize offset, and clamp it to a set length
-        attraction.target_offset =
-            if (player_transform.translation - transform.translation).length() >= precise_follow_dist {
-                Vec2::new(
-                    rng.gen_range(-max_offset_length..=max_offset_length),
-                    rng.gen_range(-max_offset_length..=max_offset_length),
-                )
-                .clamp_length_max(max_offset_length as f32)
-            } else {
-                Vec2::ZERO
-            };
+        attraction.target_offset = if distance > precise_follow_dist {
+            Vec2::new(
+                rng.gen_range(-max_offset_length..=max_offset_length),
+                rng.gen_range(-max_offset_length..=max_offset_length),
+            )
+        } else {
+            Vec2::ZERO
+        };
     }
 }
 

--- a/src/game/intersections.rs
+++ b/src/game/intersections.rs
@@ -75,6 +75,7 @@ fn handle_collectable_detection(
             player_entity,
             constants.collectable_max_vel,
             constants.collectable_accel,
+            0.,
         ));
     }
 }

--- a/src/game/mob.rs
+++ b/src/game/mob.rs
@@ -7,6 +7,11 @@ use serde::{Deserialize, Serialize};
 
 //-------------------------------------------------------------------------------------------------------------------
 
+#[derive(Debug, Component)]
+pub struct Mob;
+
+//-------------------------------------------------------------------------------------------------------------------
+
 #[derive(Reflect, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub enum MobOnDeathType
 {

--- a/src/game/spawning.rs
+++ b/src/game/spawning.rs
@@ -147,6 +147,7 @@ fn spawn_mobs(
                     AabbSize(mob_data.hitbox),
                     Health::from_max(mob_data.base_health),
                     Attraction::new(player_entity, mob_data.base_speed_tps, 0.), //no accel, start full-speed
+                    Mob,
                     StateScoped(GameState::Play),
                 ))
                 .set_sprite_animation(&animations, &mob_data.animation);

--- a/src/game/spawning.rs
+++ b/src/game/spawning.rs
@@ -146,7 +146,8 @@ fn spawn_mobs(
                     SpriteLayer::Objects,
                     AabbSize(mob_data.hitbox),
                     Health::from_max(mob_data.base_health),
-                    Attraction::new(player_entity, mob_data.base_speed_tps, 0.), //no accel, start full-speed
+                    Attraction::new(player_entity, mob_data.base_speed_tps, 0., 15.), //no accel, start
+                    // full-speed
                     Mob,
                     StateScoped(GameState::Play),
                 ))


### PR DESCRIPTION
random offsets on the position that `Attraction` entities are going to. it's zero by default, so currently only set for enemies. 

i also had to add a Mob marker component, and i fixed the jitter that happens when they get too close to the player by making them stop a short distance away.