### PR TITLE
better enemy spread

### DIFF
--- a/src/game/attraction.rs
+++ b/src/game/attraction.rs
@@ -52,39 +52,17 @@ fn update_transforms_for_attraction(
 //-------------------------------------------------------------------------------------------------------------------
 
 fn update_enemy_target_offsets(
-    mut timer: ResMut<TargetOffsetUpdateTimer>,
-    time: Res<Time>,
     mut enemies: Query<(&mut Attraction, &Transform), With<Mob>>,
     player: Query<&Transform, With<Player>>,
-    mut rng: ResMut<GameRng>,
 )
 {
-    timer.0.tick(time.delta());
-    if !timer.0.just_finished() {
-        return; // run every time the timer runs out
-    }
-    let rng = rng.rng();
     let player_transform = player.single();
-    let max_offset_length = 75.;
-    let precise_follow_dist = 75.; // when they will start following the player more precisely
     for (mut attraction, transform) in enemies.iter_mut() {
         let distance = (player_transform.translation - transform.translation).length();
-        // randomize offset, and clamp it to a set length
-        attraction.target_offset = if distance > precise_follow_dist {
-            Vec2::new(
-                rng.gen_range(-max_offset_length..=max_offset_length),
-                rng.gen_range(-max_offset_length..=max_offset_length),
-            )
-        } else {
-            Vec2::ZERO
-        };
+        // clamp offset to half of the distance between enemy and player
+        attraction.target_offset = attraction.target_offset.clamp_length_max(distance / 2.);
     }
 }
-
-//-------------------------------------------------------------------------------------------------------------------
-
-#[derive(Debug, Resource)]
-pub struct TargetOffsetUpdateTimer(pub Timer);
 
 //-------------------------------------------------------------------------------------------------------------------
 
@@ -108,7 +86,13 @@ pub struct Attraction
 
 impl Attraction
 {
-    pub fn new(target: Entity, max_velocity_tps: f32, acceleration: f32, stop_distance: f32) -> Self
+    pub fn new(
+        target: Entity,
+        max_velocity_tps: f32,
+        acceleration: f32,
+        target_offset: Vec2,
+        stop_distance: f32,
+    ) -> Self
     {
         let current_vel = match acceleration {
             0. => max_velocity_tps,
@@ -119,7 +103,7 @@ impl Attraction
             max_velocity_tps,
             acceleration,
             current_vel,
-            target_offset: Vec2::ZERO,
+            target_offset,
             stop_distance,
         }
     }
@@ -188,8 +172,7 @@ impl Plugin for AttractionPlugin
                 .chain()
                 .in_set(AttractionUpdateSet)
                 .run_if(in_state(GameState::Play)),
-        )
-        .insert_resource(TargetOffsetUpdateTimer(Timer::from_seconds(3., TimerMode::Repeating)));
+        );
     }
 }
 

--- a/src/game/attraction.rs
+++ b/src/game/attraction.rs
@@ -54,13 +54,20 @@ fn update_transforms_for_attraction(
 fn update_enemy_target_offsets(
     mut enemies: Query<(&mut Attraction, &Transform), With<Mob>>,
     player: Query<&Transform, With<Player>>,
+    mut rng: ResMut<GameRng>,
 )
 {
+    let rng = rng.rng();
     let player_transform = player.single();
     for (mut attraction, transform) in enemies.iter_mut() {
         let distance = (player_transform.translation - transform.translation).length();
+        let adjustment_amount = distance / 10.;
+        let adjustment = Vec2::new(
+            rng.gen_range(-adjustment_amount..=adjustment_amount),
+            rng.gen_range(-adjustment_amount..=adjustment_amount),
+        );
         // clamp offset to half of the distance between enemy and player
-        attraction.target_offset = attraction.target_offset.clamp_length_max(distance / 2.);
+        attraction.target_offset = (attraction.target_offset + adjustment).clamp_length_max(distance / 2.);
     }
 }
 

--- a/src/game/attraction.rs
+++ b/src/game/attraction.rs
@@ -58,28 +58,6 @@ fn update_transforms_for_attraction(
 
 //-------------------------------------------------------------------------------------------------------------------
 
-fn update_enemy_target_offsets(
-    mut enemies: Query<(&mut Attraction, &Transform), With<Mob>>,
-    player: Query<&Transform, With<Player>>,
-    mut rng: ResMut<GameRng>,
-)
-{
-    let rng = rng.rng();
-    let player_transform = player.single();
-    for (mut attraction, transform) in enemies.iter_mut() {
-        let distance = (player_transform.translation - transform.translation).length();
-        let adjustment_amount = distance / 10.;
-        let adjustment = Vec2::new(
-            rng.gen_range(-adjustment_amount..=adjustment_amount),
-            rng.gen_range(-adjustment_amount..=adjustment_amount),
-        );
-        // clamp offset to half of the distance between enemy and player
-        attraction.target_offset = (attraction.target_offset + adjustment).clamp_length_max(distance / 2.);
-    }
-}
-
-//-------------------------------------------------------------------------------------------------------------------
-
 #[derive(Component, Debug)]
 pub struct Attraction
 {
@@ -182,7 +160,7 @@ impl Plugin for AttractionPlugin
     {
         app.add_systems(
             Update,
-            (/* update_enemy_target_offsets, */update_transforms_for_attraction)
+            (update_transforms_for_attraction)
                 .chain()
                 .in_set(AttractionUpdateSet)
                 .run_if(in_state(GameState::Play)),

--- a/src/game/attraction.rs
+++ b/src/game/attraction.rs
@@ -36,9 +36,10 @@ fn update_transforms_for_attraction(
             continue;
         };
         let initial_vector = target_transform.translation - transform.translation;
-        let target_offset = attraction
-            .target_offset
-            .clamp_length(attraction.stop_distance, initial_vector.length() / 2.);
+        let target_offset = attraction.target_offset.clamp_length(
+            attraction.stop_distance,
+            attraction.stop_distance.max(initial_vector.length() / 2.),
+        );
 
         let vector = initial_vector + target_offset.extend(0.);
         // if vector.length() <= attraction.stop_distance {

--- a/src/game/attraction.rs
+++ b/src/game/attraction.rs
@@ -35,14 +35,20 @@ fn update_transforms_for_attraction(
             c.entity(entity).remove::<Attraction>();
             continue;
         };
+        let initial_vector = target_transform.translation - transform.translation;
+        let target_offset = attraction
+            .target_offset
+            .clamp_length(attraction.stop_distance, initial_vector.length() / 2.);
 
-        let vector = target_transform.translation - transform.translation + attraction.target_offset.extend(0.);
-        if vector.length() <= attraction.stop_distance {
-            continue;
-        }
+        let vector = initial_vector + target_offset.extend(0.);
+        // if vector.length() <= attraction.stop_distance {
+        //     continue;
+        // }
 
         // Move the entity toward its attraction source.
-        let distance = attraction.update_and_get_distance(delta);
+        let distance = attraction
+            .update_and_get_distance(delta)
+            .min(vector.length());
         let direction = vector.normalize();
         let movement = direction * distance;
         transform.translation += movement;
@@ -175,7 +181,7 @@ impl Plugin for AttractionPlugin
     {
         app.add_systems(
             Update,
-            (update_enemy_target_offsets, update_transforms_for_attraction)
+            (/* update_enemy_target_offsets, */update_transforms_for_attraction)
                 .chain()
                 .in_set(AttractionUpdateSet)
                 .run_if(in_state(GameState::Play)),

--- a/src/game/attraction.rs
+++ b/src/game/attraction.rs
@@ -42,9 +42,6 @@ fn update_transforms_for_attraction(
         );
 
         let vector = initial_vector + target_offset.extend(0.);
-        // if vector.length() <= attraction.stop_distance {
-        //     continue;
-        // }
 
         // Move the entity toward its attraction source.
         let distance = attraction

--- a/src/game/intersections.rs
+++ b/src/game/intersections.rs
@@ -75,6 +75,7 @@ fn handle_collectable_detection(
             player_entity,
             constants.collectable_max_vel,
             constants.collectable_accel,
+            Vec2::ZERO,
             0.,
         ));
     }

--- a/src/game/spawning.rs
+++ b/src/game/spawning.rs
@@ -133,6 +133,12 @@ fn spawn_mobs(
                 };
                 let mut entity_transform = point_transform;
                 entity_transform.translation += adjustment.extend(0.);
+                let target_offset_dist = 200.;
+                let target_offset = Vec2::new(
+                    rng.gen_range(-target_offset_dist..=target_offset_dist),
+                    rng.gen_range(-target_offset_dist..=target_offset_dist),
+                )
+                .clamp_length_max(target_offset_dist);
 
                 // Correct so the entity stays inside the map.
                 // - Incorporates mob hit box.
@@ -146,7 +152,7 @@ fn spawn_mobs(
                     SpriteLayer::Objects,
                     AabbSize(mob_data.hitbox),
                     Health::from_max(mob_data.base_health),
-                    Attraction::new(player_entity, mob_data.base_speed_tps, 0., 15.), //no accel, start
+                    Attraction::new(player_entity, mob_data.base_speed_tps, 0., target_offset, 15.), //no accel, start
                     // full-speed
                     Mob,
                     StateScoped(GameState::Play),

--- a/src/game/spawning.rs
+++ b/src/game/spawning.rs
@@ -152,7 +152,7 @@ fn spawn_mobs(
                     SpriteLayer::Objects,
                     AabbSize(mob_data.hitbox),
                     Health::from_max(mob_data.base_health),
-                    Attraction::new(player_entity, mob_data.base_speed_tps, 0., target_offset, 15.), //no accel, start
+                    Attraction::new(player_entity, mob_data.base_speed_tps, 0., target_offset, 30.), //no accel, start
                     // full-speed
                     Mob,
                     StateScoped(GameState::Play),


### PR DESCRIPTION
offsets are no longer updated separately (or at all), instead they're shrunk towards the player just before applying them, based on the distance between the two entities (currently it sits halfway, can easily be changed). 

they also no longer just stop moving when they get close enough, instead the offsets end up on the stop ring itself. this helps prevent them from clumping up too much when the player is moving around and running away from them. it does make them sometimes walk over the player to get to their position, but it's not too bad.